### PR TITLE
Remove noisy fmt.Println

### DIFF
--- a/mp4_encoder.go
+++ b/mp4_encoder.go
@@ -3,7 +3,6 @@ package mp4meta
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"image/png"
 	"io"
 	"os"
@@ -100,10 +99,8 @@ func createAndWrite(w mp4Writer, ctx mp4lib.Context, _tags *MP4Tag) error {
 			return err
 		}
 
-		if j, err := mp4lib.Marshal(w, boxData, dataCtx); err != nil {
+		if _, err := mp4lib.Marshal(w, boxData, dataCtx); err != nil {
 			return err
-		} else {
-			fmt.Println(j)
 		}
 
 		if _, err := w.EndBox(); err != nil {


### PR DESCRIPTION
It seems there is an unnecessary fmt.Println that was left in the code. Not sure if this is intentional or no, but this pull request removes it

Also, I would like to say thanks to you for making this and other libraries for working with audio metadata in go. They are pretty awesome :)